### PR TITLE
fix: resolve openeo process link for worldcereal using github raw url

### DIFF
--- a/algorithm_catalog/worldcereal_inference.json
+++ b/algorithm_catalog/worldcereal_inference.json
@@ -87,7 +87,7 @@
       "rel": "openeo-process",
       "type": "application/json",
       "title": "openEO Process Definition",
-      "href": "https://github.com/ESA-APEX/apex_algorithms/blob/main/openeo_udp/worldcereal_inference.json"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/main/openeo_udp/worldcereal_inference.json"
     },
     {
       "rel": "git",


### PR DESCRIPTION
The url needs to use the github raw url in order to return JSON response.