### PR TITLE
fix: resolve broken openeo-process links on sentinel1 stats definition

### DIFF
--- a/algorithm_catalog/sentinel1_stats.json
+++ b/algorithm_catalog/sentinel1_stats.json
@@ -88,7 +88,7 @@
             "rel": "openeo-process",
             "type": "application/json",
             "title": "openEO Process Definition",
-            "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/openeo_udp/sentinel1_stats/sentinel1_stats.json"
+            "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/main/openeo_udp/sentinel1_stats/sentinel1_stats.json"
         },
         {
             "rel": "service",


### PR DESCRIPTION
The openeo-process links was wrongly written and cause it return 404. To solve it, the url needs to include the branch name.