### PR TITLE
pin moto as it introduced S3 issues

### DIFF
--- a/qa/unittests/requirements.txt
+++ b/qa/unittests/requirements.txt
@@ -1,6 +1,6 @@
 apex-algorithm-qa-tools
 pytest>=8.2.0
-moto[s3, server]>=5.0.13
+moto[s3, server]>=5.0.13,!=5.2.0
 dirty-equals>=0.8.0
 pytest-xdist>=3.5.0
 requests_mock>=1.12.0

--- a/qa/unittests/requirements.txt
+++ b/qa/unittests/requirements.txt
@@ -1,6 +1,6 @@
 apex-algorithm-qa-tools
 pytest>=8.2.0
-moto[s3, server]>=5.0.13,!=5.2.0
+moto[s3, server]>=5.0.13,<5.2.0
 dirty-equals>=0.8.0
 pytest-xdist>=3.5.0
 requests_mock>=1.12.0


### PR DESCRIPTION
Key finding from the changelog: moto 5.2.0 has S3 bugs that were partially fixed in 5.2.1:

S3: Uploading files no longer fails with 'Unsupported protocol' (broken in 5.2.0)
S3: create_multipart_upload() is now compatible with Java SDK again (broken in 5.2.0)