### PR TITLE
Remove null. Pointed out by McGill.

### DIFF
--- a/algorithm_catalog/eurac/sentinel1_sar_coherence/openeo_udp/sentinel1_sar_coherence.json
+++ b/algorithm_catalog/eurac/sentinel1_sar_coherence/openeo_udp/sentinel1_sar_coherence.json
@@ -93,9 +93,6 @@
               "type": "string",
               "subtype": "date",
               "format": "date"
-            },
-            {
-              "type": "null"
             }
           ]
         }

--- a/algorithm_catalog/eurac/sentinel1_sar_slc_preprocessing/openeo_udp/sentinel1_sar_slc_preprocessing.json
+++ b/algorithm_catalog/eurac/sentinel1_sar_slc_preprocessing/openeo_udp/sentinel1_sar_slc_preprocessing.json
@@ -48,9 +48,6 @@
               "type": "string",
               "subtype": "date",
               "format": "date"
-            },
-            {
-              "type": "null"
             }
           ]
         }


### PR DESCRIPTION
For a long term solution, this could be avoided when automatically generating the json based on CWL.