### PR TITLE
Fix: UDPs not working

### DIFF
--- a/algorithm_catalog/developmentseed/atmospheric_resistant_vegetation_index/openeo_udp/atmospheric_resistant_vegetation_index.json
+++ b/algorithm_catalog/developmentseed/atmospheric_resistant_vegetation_index/openeo_udp/atmospheric_resistant_vegetation_index.json
@@ -9,6 +9,22 @@
           "B8A"
         ],
         "id": "SENTINEL2_L2A",
+        "properties": {
+          "eo:cloud_cover": {
+            "process_graph": {
+              "lte1": {
+                "process_id": "lte",
+                "arguments": {
+                  "x": {
+                    "from_parameter": "value"
+                  },
+                  "y": 30
+                },
+                "result": true
+              }
+            }
+          }
+        },
         "spatial_extent": {
           "from_parameter": "bounding_box"
         },
@@ -216,6 +232,15 @@
         "south": 45.174,
         "north": 45.25
       },
+      "optional": true
+    },
+    {
+      "name": "cloud_cover",
+      "description": "Maximum cloud cover percentage",
+      "schema": {
+        "type": "number"
+      },
+      "default": 30,
       "optional": true
     }
   ],

--- a/algorithm_catalog/developmentseed/atmospheric_resistant_vegetation_index/openeo_udp/atmospheric_resistant_vegetation_index.json
+++ b/algorithm_catalog/developmentseed/atmospheric_resistant_vegetation_index/openeo_udp/atmospheric_resistant_vegetation_index.json
@@ -200,6 +200,16 @@
             }
           }
         }
+      }
+    },
+    "saveresult1": {
+      "process_id": "save_result",
+      "arguments": {
+        "data": {
+          "from_node": "apply2"
+        },
+        "format": "GTiff",
+        "options": {}
       },
       "result": true
     }

--- a/algorithm_catalog/developmentseed/atmospheric_resistant_vegetation_index/openeo_udp/atmospheric_resistant_vegetation_index.json
+++ b/algorithm_catalog/developmentseed/atmospheric_resistant_vegetation_index/openeo_udp/atmospheric_resistant_vegetation_index.json
@@ -177,36 +177,11 @@
         }
       }
     },
-    "apply2": {
-      "process_id": "apply",
-      "arguments": {
-        "data": {
-          "from_node": "applydimension1"
-        },
-        "process": {
-          "process_graph": {
-            "linearscalerange1": {
-              "process_id": "linear_scale_range",
-              "arguments": {
-                "inputMax": 1,
-                "inputMin": 0,
-                "outputMax": 255,
-                "outputMin": 0,
-                "x": {
-                  "from_parameter": "x"
-                }
-              },
-              "result": true
-            }
-          }
-        }
-      }
-    },
     "saveresult1": {
       "process_id": "save_result",
       "arguments": {
         "data": {
-          "from_node": "apply2"
+          "from_node": "applydimension1"
         },
         "format": "GTiff",
         "options": {}

--- a/algorithm_catalog/developmentseed/enhanced_vegetation_index/openeo_udp/enhanced_vegetation_index.json
+++ b/algorithm_catalog/developmentseed/enhanced_vegetation_index/openeo_udp/enhanced_vegetation_index.json
@@ -669,38 +669,13 @@
         }
       }
     },
-    "apply2": {
-      "process_id": "apply",
-      "arguments": {
-        "data": {
-          "from_node": "applydimension1"
-        },
-        "process": {
-          "process_graph": {
-            "linearscalerange1": {
-              "process_id": "linear_scale_range",
-              "arguments": {
-                "inputMax": 1,
-                "inputMin": 0,
-                "outputMax": 255,
-                "outputMin": 0,
-                "x": {
-                  "from_parameter": "x"
-                }
-              },
-              "result": true
-            }
-          }
-        }
-      }
-    },
     "saveresult1": {
       "process_id": "save_result",
       "arguments": {
         "data": {
-          "from_node": "apply2"
+          "from_node": "applydimension1"
         },
-        "format": "PNG",
+        "format": "GTiff",
         "options": {}
       },
       "result": true

--- a/algorithm_catalog/developmentseed/enhanced_vegetation_index/openeo_udp/enhanced_vegetation_index.json
+++ b/algorithm_catalog/developmentseed/enhanced_vegetation_index/openeo_udp/enhanced_vegetation_index.json
@@ -8,6 +8,22 @@
           "B04"
         ],
         "id": "SENTINEL2_L2A",
+        "properties": {
+          "eo:cloud_cover": {
+            "process_graph": {
+              "lte1": {
+                "process_id": "lte",
+                "arguments": {
+                  "x": {
+                    "from_parameter": "value"
+                  },
+                  "y": 30
+                },
+                "result": true
+              }
+            }
+          }
+        },
         "spatial_extent": {
           "from_parameter": "bounding_box"
         },
@@ -16,46 +32,11 @@
         }
       }
     },
-    "maskpolygon1": {
-      "process_id": "mask_polygon",
-      "arguments": {
-        "data": {
-          "from_node": "loadcollection1"
-        },
-        "mask": {
-          "type": "Polygon",
-          "coordinates": [
-            [
-              [
-                13.5876,
-                45.4166
-              ],
-              [
-                13.5876,
-                45.4558
-              ],
-              [
-                13.4986,
-                45.4558
-              ],
-              [
-                13.4986,
-                45.4166
-              ],
-              [
-                13.5876,
-                45.4166
-              ]
-            ]
-          ]
-        }
-      }
-    },
     "reducedimension1": {
       "process_id": "reduce_dimension",
       "arguments": {
         "data": {
-          "from_node": "maskpolygon1"
+          "from_node": "loadcollection1"
         },
         "dimension": "t",
         "reducer": {
@@ -752,6 +733,15 @@
         "east": 13.5876,
         "north": 45.4558
       },
+      "optional": true
+    },
+    {
+      "name": "cloud_cover",
+      "description": "Maximum cloud cover percentage",
+      "schema": {
+        "type": "number"
+      },
+      "default": 30,
       "optional": true
     }
   ],

--- a/algorithm_catalog/developmentseed/kernel_ndvi/openeo_udp/kernel_ndvi.json
+++ b/algorithm_catalog/developmentseed/kernel_ndvi/openeo_udp/kernel_ndvi.json
@@ -9,6 +9,22 @@
           "SCL"
         ],
         "id": "SENTINEL2_L2A",
+        "properties": {
+          "eo:cloud_cover": {
+            "process_graph": {
+              "lte1": {
+                "process_id": "lte",
+                "arguments": {
+                  "x": {
+                    "from_parameter": "value"
+                  },
+                  "y": 30
+                },
+                "result": true
+              }
+            }
+          }
+        },
         "spatial_extent": {
           "from_parameter": "bounding_box"
         },
@@ -1245,6 +1261,15 @@
         "south": 45.174,
         "north": 45.25
       },
+      "optional": true
+    },
+    {
+      "name": "cloud_cover",
+      "description": "Maximum cloud cover percentage",
+      "schema": {
+        "type": "number"
+      },
+      "default": 30,
       "optional": true
     }
   ],

--- a/algorithm_catalog/developmentseed/kernel_ndvi/openeo_udp/kernel_ndvi.json
+++ b/algorithm_catalog/developmentseed/kernel_ndvi/openeo_udp/kernel_ndvi.json
@@ -1206,29 +1206,14 @@
         }
       }
     },
-    "apply1": {
-      "process_id": "apply",
+    "saveresult1": {
+      "process_id": "save_result",
       "arguments": {
         "data": {
           "from_node": "applydimension1"
         },
-        "process": {
-          "process_graph": {
-            "linearscalerange1": {
-              "process_id": "linear_scale_range",
-              "arguments": {
-                "inputMax": 1,
-                "inputMin": 0,
-                "outputMax": 255,
-                "outputMin": 0,
-                "x": {
-                  "from_parameter": "x"
-                }
-              },
-              "result": true
-            }
-          }
-        }
+        "format": "GTiff",
+        "options": {}
       },
       "result": true
     }

--- a/algorithm_catalog/developmentseed/kernel_ndvi/records/kernel_ndvi.json
+++ b/algorithm_catalog/developmentseed/kernel_ndvi/records/kernel_ndvi.json
@@ -94,7 +94,7 @@
       "rel": "application",
       "type": "application/vnd.openeo+json;type=process",
       "title": "openEO Process Definition",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/1b82a4888bc00a624d9fc80147a16a14e494ab1e/algorithm_catalog/developmentseed/kernel_ndvi/openeo_udp/kernel_ndvi.json"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/f8c3e80a122110f2654e424735b23330569f3653/algorithm_catalog/developmentseed/kernel_ndvi/openeo_udp/kernel_ndvi.json"
     },
     {
       "rel": "code",
@@ -106,7 +106,7 @@
       "rel": "webapp",
       "type": "text/html",
       "title": "OpenEO Web Editor",
-      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=kernel_ndvi&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/1b82a4888bc00a624d9fc80147a16a14e494ab1e/algorithm_catalog/developmentseed/kernel_ndvi/openeo_udp/kernel_ndvi.json&server=https://openeo.dataspace.copernicus.eu/"
+      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=kernel_ndvi&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/f8c3e80a122110f2654e424735b23330569f3653/algorithm_catalog/developmentseed/kernel_ndvi/openeo_udp/kernel_ndvi.json&server=https://openeo.dataspace.copernicus.eu/"
     },
     {
       "rel": "service",
@@ -136,13 +136,13 @@
       "rel": "preview",
       "type": "image/png",
       "title": "kNDVI Visualization",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/1b82a4888bc00a624d9fc80147a16a14e494ab1e/algorithm_catalog/developmentseed/kernel_ndvi/records/preview.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/f8c3e80a122110f2654e424735b23330569f3653/algorithm_catalog/developmentseed/kernel_ndvi/records/preview.png"
     },
     {
       "rel": "thumbnail",
       "type": "image/png",
       "title": "Thumbnail image",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/1b82a4888bc00a624d9fc80147a16a14e494ab1e/algorithm_catalog/developmentseed/kernel_ndvi/records/thumbnail.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/f8c3e80a122110f2654e424735b23330569f3653/algorithm_catalog/developmentseed/kernel_ndvi/records/thumbnail.png"
     },
     {
       "rel": "cite-as",

--- a/algorithm_catalog/developmentseed/kernel_ndvi/records/kernel_ndvi.json
+++ b/algorithm_catalog/developmentseed/kernel_ndvi/records/kernel_ndvi.json
@@ -94,7 +94,7 @@
       "rel": "application",
       "type": "application/vnd.openeo+json;type=process",
       "title": "openEO Process Definition",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/f8c3e80a122110f2654e424735b23330569f3653/algorithm_catalog/developmentseed/kernel_ndvi/openeo_udp/kernel_ndvi.json"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/950b051c56df427787b45dc61643180f84be7d49/algorithm_catalog/developmentseed/kernel_ndvi/openeo_udp/kernel_ndvi.json"
     },
     {
       "rel": "code",
@@ -106,7 +106,7 @@
       "rel": "webapp",
       "type": "text/html",
       "title": "OpenEO Web Editor",
-      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=kernel_ndvi&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/f8c3e80a122110f2654e424735b23330569f3653/algorithm_catalog/developmentseed/kernel_ndvi/openeo_udp/kernel_ndvi.json&server=https://openeo.dataspace.copernicus.eu/"
+      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=kernel_ndvi&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/950b051c56df427787b45dc61643180f84be7d49/algorithm_catalog/developmentseed/kernel_ndvi/openeo_udp/kernel_ndvi.json&server=https://openeo.dataspace.copernicus.eu/"
     },
     {
       "rel": "service",
@@ -136,13 +136,13 @@
       "rel": "preview",
       "type": "image/png",
       "title": "kNDVI Visualization",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/f8c3e80a122110f2654e424735b23330569f3653/algorithm_catalog/developmentseed/kernel_ndvi/records/preview.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/950b051c56df427787b45dc61643180f84be7d49/algorithm_catalog/developmentseed/kernel_ndvi/records/preview.png"
     },
     {
       "rel": "thumbnail",
       "type": "image/png",
       "title": "Thumbnail image",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/f8c3e80a122110f2654e424735b23330569f3653/algorithm_catalog/developmentseed/kernel_ndvi/records/thumbnail.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/950b051c56df427787b45dc61643180f84be7d49/algorithm_catalog/developmentseed/kernel_ndvi/records/thumbnail.png"
     },
     {
       "rel": "cite-as",

--- a/algorithm_catalog/developmentseed/leaf_area_index/openeo_udp/leaf_area_index.json
+++ b/algorithm_catalog/developmentseed/leaf_area_index/openeo_udp/leaf_area_index.json
@@ -42,46 +42,11 @@
         }
       }
     },
-    "maskpolygon1": {
-      "process_id": "mask_polygon",
-      "arguments": {
-        "data": {
-          "from_node": "loadcollection1"
-        },
-        "mask": {
-          "type": "Polygon",
-          "coordinates": [
-            [
-              [
-                14.27,
-                45.174
-              ],
-              [
-                14.27,
-                45.25
-              ],
-              [
-                14.09,
-                45.25
-              ],
-              [
-                14.09,
-                45.174
-              ],
-              [
-                14.27,
-                45.174
-              ]
-            ]
-          ]
-        }
-      }
-    },
     "reducedimension1": {
       "process_id": "reduce_dimension",
       "arguments": {
         "data": {
-          "from_node": "maskpolygon1"
+          "from_node": "loadcollection1"
         },
         "dimension": "t",
         "reducer": {

--- a/algorithm_catalog/developmentseed/leaf_area_index/records/leaf_area_index.json
+++ b/algorithm_catalog/developmentseed/leaf_area_index/records/leaf_area_index.json
@@ -94,7 +94,7 @@
       "rel": "application",
       "type": "application/vnd.openeo+json;type=process",
       "title": "openEO Process Definition",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/9ce5b44189a16a8c3b4d26839e5261a2e09883ef/algorithm_catalog/developmentseed/leaf_area_index/openeo_udp/leaf_area_index.json"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/3fbed3d22098e2bb5b3b7e614b597a5a47225529/algorithm_catalog/developmentseed/leaf_area_index/openeo_udp/leaf_area_index.json"
     },
     {
       "rel": "code",
@@ -106,7 +106,7 @@
       "rel": "webapp",
       "type": "text/html",
       "title": "OpenEO Web Editor",
-      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=leaf_area_index&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/9ce5b44189a16a8c3b4d26839e5261a2e09883ef/algorithm_catalog/developmentseed/leaf_area_index/openeo_udp/leaf_area_index.json&server=https://openeo.dataspace.copernicus.eu/"
+      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=leaf_area_index&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/3fbed3d22098e2bb5b3b7e614b597a5a47225529/algorithm_catalog/developmentseed/leaf_area_index/openeo_udp/leaf_area_index.json&server=https://openeo.dataspace.copernicus.eu/"
     },
     {
       "rel": "service",
@@ -136,13 +136,13 @@
       "rel": "preview",
       "type": "image/png",
       "title": "Leaf Area Index Calculation",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/9ce5b44189a16a8c3b4d26839e5261a2e09883ef/algorithm_catalog/developmentseed/leaf_area_index/records/preview.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/3fbed3d22098e2bb5b3b7e614b597a5a47225529/algorithm_catalog/developmentseed/leaf_area_index/records/preview.png"
     },
     {
       "rel": "thumbnail",
       "type": "image/png",
       "title": "Thumbnail image",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/9ce5b44189a16a8c3b4d26839e5261a2e09883ef/algorithm_catalog/developmentseed/leaf_area_index/records/thumbnail.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/3fbed3d22098e2bb5b3b7e614b597a5a47225529/algorithm_catalog/developmentseed/leaf_area_index/records/thumbnail.png"
     },
     {
       "rel": "cite-as",

--- a/algorithm_catalog/developmentseed/plant-senescence-reflectance-index/openeo_udp/plant-senescence-reflectance-index.json
+++ b/algorithm_catalog/developmentseed/plant-senescence-reflectance-index/openeo_udp/plant-senescence-reflectance-index.json
@@ -9,6 +9,22 @@
           "B06"
         ],
         "id": "SENTINEL2_L2A",
+        "properties": {
+          "eo:cloud_cover": {
+            "process_graph": {
+              "lte1": {
+                "process_id": "lte",
+                "arguments": {
+                  "x": {
+                    "from_parameter": "value"
+                  },
+                  "y": 30
+                },
+                "result": true
+              }
+            }
+          }
+        },
         "spatial_extent": {
           "from_parameter": "bounding_box"
         },
@@ -194,7 +210,7 @@
                 "y": 0.4
               }
             },
-            "lte1": {
+            "lte2": {
               "process_id": "lte",
               "arguments": {
                 "x": {
@@ -210,7 +226,7 @@
                   "from_node": "gt2"
                 },
                 "y": {
-                  "from_node": "lte1"
+                  "from_node": "lte2"
                 }
               }
             },
@@ -235,7 +251,7 @@
                 "y": -0.2
               }
             },
-            "lte2": {
+            "lte3": {
               "process_id": "lte",
               "arguments": {
                 "x": {
@@ -251,7 +267,7 @@
                   "from_node": "gt3"
                 },
                 "y": {
-                  "from_node": "lte2"
+                  "from_node": "lte3"
                 }
               }
             },
@@ -269,7 +285,7 @@
                 }
               }
             },
-            "lte3": {
+            "lte4": {
               "process_id": "lte",
               "arguments": {
                 "x": {
@@ -286,7 +302,7 @@
                   "from_node": "if3"
                 },
                 "value": {
-                  "from_node": "lte3"
+                  "from_node": "lte4"
                 }
               },
               "result": true
@@ -295,29 +311,14 @@
         }
       }
     },
-    "apply2": {
-      "process_id": "apply",
+    "saveresult1": {
+      "process_id": "save_result",
       "arguments": {
         "data": {
           "from_node": "applydimension1"
         },
-        "process": {
-          "process_graph": {
-            "linearscalerange1": {
-              "process_id": "linear_scale_range",
-              "arguments": {
-                "inputMax": 1,
-                "inputMin": 0,
-                "outputMax": 255,
-                "outputMin": 0,
-                "x": {
-                  "from_parameter": "x"
-                }
-              },
-              "result": true
-            }
-          }
-        }
+        "format": "GTiff",
+        "options": {}
       },
       "result": true
     }
@@ -349,6 +350,15 @@
         "south": 45.174,
         "north": 45.25
       },
+      "optional": true
+    },
+    {
+      "name": "cloud_cover",
+      "description": "Maximum cloud cover percentage",
+      "schema": {
+        "type": "number"
+      },
+      "default": 30,
       "optional": true
     }
   ],

--- a/algorithm_catalog/developmentseed/plant-senescence-reflectance-index/records/plant-senescence-reflectance-index.json
+++ b/algorithm_catalog/developmentseed/plant-senescence-reflectance-index/records/plant-senescence-reflectance-index.json
@@ -93,7 +93,7 @@
       "rel": "application",
       "type": "application/vnd.openeo+json;type=process",
       "title": "openEO Process Definition",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/50de41b98bed0179d273629dc970696cac6787bc/algorithm_catalog/developmentseed/plant-senescence-reflectance-index/openeo_udp/plant-senescence-reflectance-index.json"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/3fbed3d22098e2bb5b3b7e614b597a5a47225529/algorithm_catalog/developmentseed/plant-senescence-reflectance-index/openeo_udp/plant-senescence-reflectance-index.json"
     },
     {
       "rel": "code",
@@ -105,7 +105,7 @@
       "rel": "webapp",
       "type": "text/html",
       "title": "OpenEO Web Editor",
-      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=plant-senescence-reflectance-index&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/50de41b98bed0179d273629dc970696cac6787bc/algorithm_catalog/developmentseed/plant-senescence-reflectance-index/openeo_udp/plant-senescence-reflectance-index.json&server=https://openeo.dataspace.copernicus.eu/"
+      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=plant-senescence-reflectance-index&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/3fbed3d22098e2bb5b3b7e614b597a5a47225529/algorithm_catalog/developmentseed/plant-senescence-reflectance-index/openeo_udp/plant-senescence-reflectance-index.json&server=https://openeo.dataspace.copernicus.eu/"
     },
     {
       "rel": "service",
@@ -135,13 +135,13 @@
       "rel": "preview",
       "type": "image/png",
       "title": "PSRI Calculation",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/50de41b98bed0179d273629dc970696cac6787bc/algorithm_catalog/developmentseed/plant-senescence-reflectance-index/records/preview.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/3fbed3d22098e2bb5b3b7e614b597a5a47225529/algorithm_catalog/developmentseed/plant-senescence-reflectance-index/records/preview.png"
     },
     {
       "rel": "thumbnail",
       "type": "image/png",
       "title": "Thumbnail image",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/50de41b98bed0179d273629dc970696cac6787bc/algorithm_catalog/developmentseed/plant-senescence-reflectance-index/records/thumbnail.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/3fbed3d22098e2bb5b3b7e614b597a5a47225529/algorithm_catalog/developmentseed/plant-senescence-reflectance-index/records/thumbnail.png"
     },
     {
       "rel": "cite-as",

--- a/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json
+++ b/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json
@@ -29,11 +29,15 @@
           }
         },
         "spatial_extent": {
-          "from_parameter": "bounding_box"
+          "west": -7.91,
+          "south": 40.14,
+          "east": -7.62,
+          "north": 40.35
         },
-        "temporal_extent": {
-          "from_parameter": "time"
-        }
+        "temporal_extent": [
+          "2025-08-19",
+          "2025-08-22"
+        ]
       }
     },
     "maskpolygon1": {

--- a/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json
+++ b/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json
@@ -29,49 +29,10 @@
           }
         },
         "spatial_extent": {
-          "west": -7.91,
-          "south": 40.14,
-          "east": -7.62,
-          "north": 40.35
+          "from_parameter": "bounding_box"
         },
-        "temporal_extent": [
-          "2025-08-19",
-          "2025-08-22"
-        ]
-      }
-    },
-    "maskpolygon1": {
-      "process_id": "mask_polygon",
-      "arguments": {
-        "data": {
-          "from_node": "loadcollection1"
-        },
-        "mask": {
-          "type": "Polygon",
-          "coordinates": [
-            [
-              [
-                -7.62,
-                40.14
-              ],
-              [
-                -7.62,
-                40.35
-              ],
-              [
-                -7.91,
-                40.35
-              ],
-              [
-                -7.91,
-                40.14
-              ],
-              [
-                -7.62,
-                40.14
-              ]
-            ]
-          ]
+        "temporal_extent": {
+          "from_parameter": "time"
         }
       }
     },
@@ -79,7 +40,7 @@
       "process_id": "reduce_dimension",
       "arguments": {
         "data": {
-          "from_node": "maskpolygon1"
+          "from_node": "loadcollection1"
         },
         "dimension": "t",
         "reducer": {

--- a/algorithm_catalog/developmentseed/wildfire_visualization/records/wildfire_visualization.json
+++ b/algorithm_catalog/developmentseed/wildfire_visualization/records/wildfire_visualization.json
@@ -93,7 +93,7 @@
       "rel": "application",
       "type": "application/vnd.openeo+json;type=process",
       "title": "openEO Process Definition",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/main/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/80b072a9649c92dfa2b7eeb111eeddb1ed8ad2eb/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json"
     },
     {
       "rel": "code",
@@ -105,7 +105,7 @@
       "rel": "webapp",
       "type": "text/html",
       "title": "OpenEO Web Editor",
-      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=wildfire_visualization&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/main/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json&server=https://openeo.dataspace.copernicus.eu/"
+      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=wildfire_visualization&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/80b072a9649c92dfa2b7eeb111eeddb1ed8ad2eb/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json&server=https://openeo.dataspace.copernicus.eu/"
     },
     {
       "rel": "service",
@@ -117,7 +117,7 @@
       "rel": "notebook",
       "type": "application/x-ipynb+json",
       "title": "Algorithm to Visualize Wildfire-Affected Areas notebook",
-      "href": "https://raw.githubusercontent.com/developmentseed/openeo-udp/068cef713c13e0fe472fffa212b1fa3b75d0b50d/notebooks/sentinel/sentinel-2/fire_and_disaster_monitoring/wildfire_visualization.ipynb"
+      "href": "https://raw.githubusercontent.com/developmentseed/openeo-udp/refs/head/main/notebooks/sentinel/sentinel-2/fire_and_disaster_monitoring/wildfire_visualization.ipynb"
     },
     {
       "rel": "platform",
@@ -135,13 +135,13 @@
       "rel": "preview",
       "type": "image/png",
       "title": "Wildfire Visualization",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/main/algorithm_catalog/developmentseed/wildfire_visualization/records/preview.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/80b072a9649c92dfa2b7eeb111eeddb1ed8ad2eb/algorithm_catalog/developmentseed/wildfire_visualization/records/preview.png"
     },
     {
       "rel": "thumbnail",
       "type": "image/png",
       "title": "Thumbnail image",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/main/algorithm_catalog/developmentseed/wildfire_visualization/records/thumbnail.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/80b072a9649c92dfa2b7eeb111eeddb1ed8ad2eb/algorithm_catalog/developmentseed/wildfire_visualization/records/thumbnail.png"
     },
     {
       "rel": "cite-as",

--- a/algorithm_catalog/developmentseed/wildfire_visualization/records/wildfire_visualization.json
+++ b/algorithm_catalog/developmentseed/wildfire_visualization/records/wildfire_visualization.json
@@ -93,7 +93,7 @@
       "rel": "application",
       "type": "application/vnd.openeo+json;type=process",
       "title": "openEO Process Definition",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/80b072a9649c92dfa2b7eeb111eeddb1ed8ad2eb/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/afb39c0fa78cb04fe78a3a679767dcc364f90f4d/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json"
     },
     {
       "rel": "code",
@@ -105,7 +105,7 @@
       "rel": "webapp",
       "type": "text/html",
       "title": "OpenEO Web Editor",
-      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=wildfire_visualization&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/80b072a9649c92dfa2b7eeb111eeddb1ed8ad2eb/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json&server=https://openeo.dataspace.copernicus.eu/"
+      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=wildfire_visualization&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/afb39c0fa78cb04fe78a3a679767dcc364f90f4d/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json&server=https://openeo.dataspace.copernicus.eu/"
     },
     {
       "rel": "service",
@@ -135,13 +135,13 @@
       "rel": "preview",
       "type": "image/png",
       "title": "Wildfire Visualization",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/80b072a9649c92dfa2b7eeb111eeddb1ed8ad2eb/algorithm_catalog/developmentseed/wildfire_visualization/records/preview.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/afb39c0fa78cb04fe78a3a679767dcc364f90f4d/algorithm_catalog/developmentseed/wildfire_visualization/records/preview.png"
     },
     {
       "rel": "thumbnail",
       "type": "image/png",
       "title": "Thumbnail image",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/80b072a9649c92dfa2b7eeb111eeddb1ed8ad2eb/algorithm_catalog/developmentseed/wildfire_visualization/records/thumbnail.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/afb39c0fa78cb04fe78a3a679767dcc364f90f4d/algorithm_catalog/developmentseed/wildfire_visualization/records/thumbnail.png"
     },
     {
       "rel": "cite-as",

--- a/algorithm_catalog/developmentseed/wildfire_visualization/records/wildfire_visualization.json
+++ b/algorithm_catalog/developmentseed/wildfire_visualization/records/wildfire_visualization.json
@@ -117,7 +117,7 @@
       "rel": "notebook",
       "type": "application/x-ipynb+json",
       "title": "Algorithm to Visualize Wildfire-Affected Areas notebook",
-      "href": "https://raw.githubusercontent.com/developmentseed/openeo-udp/refs/head/main/notebooks/sentinel/sentinel-2/fire_and_disaster_monitoring/wildfire_visualization.ipynb"
+      "href": "https://raw.githubusercontent.com/developmentseed/openeo-udp/refs/heads/main/notebooks/sentinel/sentinel-2/fire_and_disaster_monitoring/wildfire_visualization.ipynb"
     },
     {
       "rel": "platform",

--- a/algorithm_catalog/developmentseed/wildfire_visualization/records/wildfire_visualization.json
+++ b/algorithm_catalog/developmentseed/wildfire_visualization/records/wildfire_visualization.json
@@ -93,7 +93,7 @@
       "rel": "application",
       "type": "application/vnd.openeo+json;type=process",
       "title": "openEO Process Definition",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/afb39c0fa78cb04fe78a3a679767dcc364f90f4d/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/main/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json"
     },
     {
       "rel": "code",
@@ -105,7 +105,7 @@
       "rel": "webapp",
       "type": "text/html",
       "title": "OpenEO Web Editor",
-      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=wildfire_visualization&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/afb39c0fa78cb04fe78a3a679767dcc364f90f4d/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json&server=https://openeo.dataspace.copernicus.eu/"
+      "href": "https://editor.openeo.org/?wizard=UDP&wizard%7Eprocess=wildfire_visualization&wizard%7EprocessUrl=https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/main/algorithm_catalog/developmentseed/wildfire_visualization/openeo_udp/wildfire_visualization.json&server=https://openeo.dataspace.copernicus.eu/"
     },
     {
       "rel": "service",
@@ -135,13 +135,13 @@
       "rel": "preview",
       "type": "image/png",
       "title": "Wildfire Visualization",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/afb39c0fa78cb04fe78a3a679767dcc364f90f4d/algorithm_catalog/developmentseed/wildfire_visualization/records/preview.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/main/algorithm_catalog/developmentseed/wildfire_visualization/records/preview.png"
     },
     {
       "rel": "thumbnail",
       "type": "image/png",
       "title": "Thumbnail image",
-      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/afb39c0fa78cb04fe78a3a679767dcc364f90f4d/algorithm_catalog/developmentseed/wildfire_visualization/records/thumbnail.png"
+      "href": "https://raw.githubusercontent.com/ESA-APEx/apex_algorithms/main/algorithm_catalog/developmentseed/wildfire_visualization/records/thumbnail.png"
     },
     {
       "rel": "cite-as",


### PR DESCRIPTION
Related to #580 

I needed to fix some UDPs to test in the browser. They all work well and standardize now. I confirmed that they work as intended and not bounded to a specific/hardcoded spatial and temporal bounds. 

Even though I'm quite sure that re-target the branch to `ESA-APEx:main` would include all the changes from `ESA-APEx:fixes_devseed_udps` (2 commits) and `developmentseed:fixes_devseed_udps` (17 commits), I'm still hesitant to do it. I set `developmentseed:fixes_devseed_udps` to track the upstream branch with the same name. Need input on this

Issues:
- [x] Wildfire Visualization: Removes `mask_polygon` process with hard-coded bounds
- [x] Atmospheric Resistant Vegetation Index: Resolves output format definition
- [x] Enhanced Vegetation Index: Removes `mask_polygon` process with hard-coded bounds
- [x] Kernel NDVI: Add file format and cloud filter
- [x] LAI: Removes `mask_polygon` process with hard-coded bounds
- [x] PSRI: Resolves empty output file format and cloud filter